### PR TITLE
Rename temp dir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       env:
         envName: ${{ matrix.platform.name }}
       run: |
-        ./build_deps.sh release
+        ./build_deps.sh RelWithDebInfo
     - name: Publish Build Artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -129,6 +129,7 @@ jobs:
 
       - name: Create Release
         id: create_release
+        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
           draft: false

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,11 @@
+name: Scheduled
+run-name: Scheduled Actions
+on:
+  schedule:
+    - cron: 20 0 * * *
+permissions:
+  contents: write
+jobs:
+  build-project:
+    name: Build
+    uses: ./.github/workflows/build.yml

--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
 # ares-deps
 
-ares-deps is a group of build scripts for precompiling and packaging dependencies for [ares](https://github.com/ares-emulator/ares) on macOS and Windows.
+ares-deps is a group of build scripts for precompiling and packaging dependencies for [ares](https://github.com/ares-emulator/ares) on macOS and Windows. ares-deps also pre-packages certain non-library resources for Linux.
 
-ares-deps is designed to be pulled in at configure/generation time when building ares, such that any necessary libraries can be pulled in for any build configuration, included and linked appropriately, and finally packaged correctly in the app bundle or rundir as appropriate.
+ares-deps is designed to be pulled in at configure/generation time when building ares, such that any necessary libraries and data can be pulled in for any build configuration, included and linked appropriately, and finally packaged correctly in the app bundle or rundir as appropriate.
 
 ## Running
 
-If you need to compile ares-deps locally, run `./build_deps.sh <config>`, providing either `debug`, `release`, or `optimized` for the config argument.
+If you need to compile ares-deps locally, run `./build_deps.sh <config>`, providing either `<Debug|Release|RelWithDebInfo|MinSizeRel>` for the configuration.
 
 ## Dependency specifics
 
-Dependency build functions are provided in a `<dependency>` file in the `deps.macos` or `deps.windows` directory as appropriate. These files should define the following functions that will build and package the dependency:
+Dependency build functions are provided in a `<dependency>` file in the `deps.macos`, `deps.windows`, or `deps.linux` directory as appropriate. These files should define the following functions that will build and package the dependency:
 
 * `<dependency>_setup()`: This function should clone the repository, checkout a specific commit, and perform any other setup required to build, such as mapping build configurations if necessary.
 * `<dependency>_patch()`: This function should apply any necessary patches to the code prior to building.
 * `<dependency>_build()`: This function should build the library in the provided configuration.
-* `<dependency>_install()`: This function should copy build products to the final output directories. The product directory takes the form `ares-deps-$os-$arch-$config` depending on environment and build configuration. Within the build output directory:
-  * The `lib` folder should contain all .dylibs or .dlls for the library, as well as all debug symbol files if necessary.
+
+The above three functions are called from within the `build_temp` working directory.
+
+* `<dependency>_install()`: This function should copy build products to the final output directory. The product directory is named `ares-deps` and should be treated as a prefix; that is, it will contain `lib`, `share`, `include`, etc. directories per Unix-like prefix structures.
+  * The `lib` folder should contain all .dylibs or .dlls for the library, as well as all debug symbol files.
   * The `include/<dependency>/` directory should contain any necessary header files for the library.
-  * Any relevant licenses for the library should be placed in the `licenses/<dependency>` directory and named appropriately.
+  * Data dependencies go into the `share` folder.
+  * Any relevant licenses for the library should be placed in the `licenses/<dependency>/` directory and named appropriately.
+  
+This last function is called from the base directory of this repository.

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -32,8 +32,8 @@ build_deps() {
     dependencies+=("$(basename "$dependency")")
   done
   
-  mkdir -p "build_temp_$os-$arch-$config"
-  cd "build_temp_$os-$arch-$config"
+  mkdir -p "build_temp"
+  cd "build_temp"
   for dependency in "${dependencies[@]}"
   do
     # set up the dependency

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -9,8 +9,7 @@ build_deps() {
   arch=''
   check_architecture arch
   
-  config="${1-release}"
-  check_config $config config
+  config="${1-RelWithDebInfo}"
   
   # where are we?
   SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -81,18 +80,6 @@ check_architecture() {
     echo $unametest
     local unameout=$(uname -p)
     eval "$1=$unameout"
-  fi
-}
-
-check_config() {
-  if [[ $1 == "debug" ]]; then
-    eval "$2='Debug'"
-  elif [[ $1 == 'release' ]]; then
-    eval "$2='RelWithDebInfo'"
-  elif [[ $1 == 'optimized' ]]; then
-    eval "$2='MinSizeRel'"
-  else
-    eval "$2='RelWithDebInfo'"
   fi
 }
 

--- a/deps.linux/librashader
+++ b/deps.linux/librashader
@@ -34,7 +34,7 @@ librashader_build() {
 librashader_install() {
   mkdir -p ares-deps/include/librashader/
   mkdir -p ares-deps/licenses/librashader/
-  cp -R "build_temp_$os-$arch-$config"/librashader/include/. ares-deps/include/librashader/
-  cp "build_temp_$os-$arch-$config"/librashader/LICENSE.md ares-deps/licenses/librashader/LICENSE.md
-  cp "build_temp_$os-$arch-$config"/librashader/LICENSE-GPL.md ares-deps/licenses/librashader/LICENSE-GPL.md
+  cp -R build_temp/librashader/include/. ares-deps/include/librashader/
+  cp build_temp/librashader/LICENSE.md ares-deps/licenses/librashader/LICENSE.md
+  cp build_temp/librashader/LICENSE-GPL.md ares-deps/licenses/librashader/LICENSE-GPL.md
 }

--- a/deps.linux/slang_shaders
+++ b/deps.linux/slang_shaders
@@ -36,5 +36,5 @@ slang_shaders_build() {
 
 slang_shaders_install() {
   mkdir -p ares-deps/share/libretro/shaders/shaders_slang
-  cp -R "build_temp_$os-$arch-$config"/slang-shaders/ ares-deps/share/libretro/shaders/shaders_slang/
+  cp -R build_temp/slang-shaders/ ares-deps/share/libretro/shaders/shaders_slang/
 }

--- a/deps.macos/librashader
+++ b/deps.macos/librashader
@@ -37,9 +37,9 @@ librashader_build() {
 
 librashader_install() {
   pwd
-  ditto "build_temp_$os-$arch-$config"/librashader/include ares-deps/include/librashader/
-  ditto "build_temp_$os-$arch-$config"/librashader/target/${librashader_profile}/librashader.dylib ares-deps/lib/librashader.dylib
+  ditto build_temp/librashader/include ares-deps/include/librashader/
+  ditto build_temp/librashader/target/${librashader_profile}/librashader.dylib ares-deps/lib/librashader.dylib
   fix_rpaths ares-deps/lib/librashader.dylib
-  ditto "build_temp_$os-$arch-$config"/librashader/LICENSE.md ares-deps/licenses/librashader/LICENSE.md
-  ditto "build_temp_$os-$arch-$config"/librashader/LICENSE-GPL.md ares-deps/licenses/librashader/LICENSE-GPL.md
+  ditto build_temp/librashader/LICENSE.md ares-deps/licenses/librashader/LICENSE.md
+  ditto build_temp/librashader/LICENSE-GPL.md ares-deps/licenses/librashader/LICENSE-GPL.md
 }

--- a/deps.macos/moltenvk
+++ b/deps.macos/moltenvk
@@ -28,9 +28,9 @@ moltenvk_build() {
 }
 
 moltenvk_install() {
-  ditto "build_temp_$os-$arch-$config"/MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib ares-deps/lib/libMoltenVK.dylib
+  ditto build_temp/MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib ares-deps/lib/libMoltenVK.dylib
   if [[ -f "Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib.dSYM" ]]; then
-    ditto "build_temp_$os-$arch-$config"/MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib.dSYM ares-deps/lib/MoltenVK/libMoltenVK.dylib.dSYM
+    ditto build_temp/MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib.dSYM ares-deps/lib/MoltenVK/libMoltenVK.dylib.dSYM
   fi
-  ditto "build_temp_$os-$arch-$config"/MoltenVK/LICENSE ares-deps/licenses/MoltenVK/LICENSE
+  ditto build_temp/MoltenVK/LICENSE ares-deps/licenses/MoltenVK/LICENSE
 }

--- a/deps.macos/sdl
+++ b/deps.macos/sdl
@@ -49,10 +49,10 @@ sdl_build() {
 }
 
 sdl_install() {
-  ditto "build_temp_$os-$arch-$config"/SDL/build/libSDL2-2.0.0.dylib ares-deps/lib/libSDL2-2.0.0.dylib
+  ditto build_temp/SDL/build/libSDL2-2.0.0.dylib ares-deps/lib/libSDL2-2.0.0.dylib
   mkdir -p ares-deps/include/SDL2
-  ditto "build_temp_$os-$arch-$config"/SDL/include ares-deps/include/SDL2
-  ditto "build_temp_$os-$arch-$config"/SDL/LICENSE.txt ares-deps/licenses/SDL2/LICENSE.txt
+  ditto build_temp/SDL/include ares-deps/include/SDL2
+  ditto build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL2/LICENSE.txt
 }
 
 

--- a/deps.macos/slang_shaders
+++ b/deps.macos/slang_shaders
@@ -35,7 +35,7 @@ slang_shaders_build() {
 }
 
 slang_shaders_install() {
-  ditto "build_temp_$os-$arch-$config"/slang-shaders ares-deps/share/libretro/shaders/shaders_slang
+  ditto "build_temp"/slang-shaders ares-deps/share/libretro/shaders/shaders_slang
 }
 
 

--- a/deps.windows/librashader
+++ b/deps.windows/librashader
@@ -41,16 +41,16 @@ librashader_build() {
 librashader_install() {
   mkdir -p ares-deps/include/librashader/
   mkdir -p ares-deps/lib/
-  cp -R "build_temp_$os-$arch-$config"/librashader/include/. ares-deps/include/librashader/
+  cp -R build_temp/librashader/include/. ares-deps/include/librashader/
   if [[ $envName = windows-arm64 ]]; then
     local targetName="aarch64-pc-windows-msvc"
   else
     local targetName=""
   fi
-  cp -R "build_temp_$os-$arch-$config"/librashader/target/${targetName}/${librashader_profile}/librashader.d ares-deps/lib/librashader.d
-  cp -R "build_temp_$os-$arch-$config"/librashader/target/${targetName}/${librashader_profile}/librashader.dll ares-deps/lib/librashader.dll
-  cp -R "build_temp_$os-$arch-$config"/librashader/target/${targetName}/${librashader_profile}/librashader.dll.exp ares-deps/lib/librashader.dll.exp
-  cp -R "build_temp_$os-$arch-$config"/librashader/target/${targetName}/${librashader_profile}/librashader.dll.lib ares-deps/lib/librashader.dll.lib
+  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.d ares-deps/lib/librashader.d
+  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.dll ares-deps/lib/librashader.dll
+  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.dll.exp ares-deps/lib/librashader.dll.exp
+  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.dll.lib ares-deps/lib/librashader.dll.lib
   mv ares-deps/lib/librashader.dll.lib ares-deps/lib/librashader.lib
-  cp -R "build_temp_$os-$arch-$config"/librashader/target/${targetName}/${librashader_profile}/librashader.pdb ares-deps/lib/librashader.pdb
+  cp -R build_temp/librashader/target/${targetName}/${librashader_profile}/librashader.pdb ares-deps/lib/librashader.pdb
 }

--- a/deps.windows/sdl
+++ b/deps.windows/sdl
@@ -42,6 +42,8 @@ sdl_build() {
   mkdir -p build
   pushd build
 
+  echo ${config}
+
   cmake .. "${SDLARGS[@]}" -G "Visual Studio 17 2022"
   cmake --build . --config ${config}
 

--- a/deps.windows/sdl
+++ b/deps.windows/sdl
@@ -53,14 +53,14 @@ sdl_install() {
   mkdir -p ares-deps/lib
   mkdir -p ares-deps/include/SDL2
   mkdir -p ares-deps/licenses/SDL2
-  cp -R "build_temp_$os-$arch-$config"/SDL/build/${config}/SDL2.dll ares-deps/lib/SDL2.dll
-  cp -R "build_temp_$os-$arch-$config"/SDL/build/${config}/SDL2.pdb ares-deps/lib/SDL2.pdb
-  cp -R "build_temp_$os-$arch-$config"/SDL/build/${config}/SDL2.exp ares-deps/lib/SDL2.exp
-  cp -R "build_temp_$os-$arch-$config"/SDL/build/${config}/SDL2.lib ares-deps/lib/SDL2.lib
+  cp -R build_temp/SDL/build/${config}/SDL2.dll ares-deps/lib/SDL2.dll
+  cp -R build_temp/SDL/build/${config}/SDL2.pdb ares-deps/lib/SDL2.pdb
+  cp -R build_temp/SDL/build/${config}/SDL2.exp ares-deps/lib/SDL2.exp
+  cp -R build_temp/SDL/build/${config}/SDL2.lib ares-deps/lib/SDL2.lib
   mkdir -p ares-deps/include/SDL2
-  cp -R "build_temp_$os-$arch-$config"/SDL/build/include/SDL2/. ares-deps/include/SDL2/
-  cp -R "build_temp_$os-$arch-$config"/SDL/build/include-config-${config}/SDL2/. ares-deps/include/SDL2/
-  cp -R "build_temp_$os-$arch-$config"/SDL/LICENSE.txt ares-deps/licenses/SDL2/LICENSE.txt
+  cp -R build_temp/SDL/build/include/SDL2/. ares-deps/include/SDL2/
+  cp -R build_temp/SDL/build/include-config-${config}/SDL2/. ares-deps/include/SDL2/
+  cp -R build_temp/SDL/LICENSE.txt ares-deps/licenses/SDL2/LICENSE.txt
 }
 
 

--- a/deps.windows/slang_shaders
+++ b/deps.windows/slang_shaders
@@ -36,7 +36,7 @@ slang_shaders_build() {
 
 slang_shaders_install() {
   mkdir -p ares-deps/share/libretro/shaders/shaders_slang
-  cp -R "build_temp_$os-$arch-$config"/slang-shaders/ ares-deps/share/libretro/shaders/shaders_slang/
+  cp -R build_temp/slang-shaders/ ares-deps/share/libretro/shaders/shaders_slang/
 }
 
 


### PR DESCRIPTION
The temp dir had a needlessly complex name and considered that you might build multiple configurations simultaneously with the same instance; it's a simpler design to just build one configuration at once.